### PR TITLE
Feature/docker file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+commitlint.config.js
+LICENSE
+*.md 
+.*
+sonar-project.properties
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:16.17.0
+
+LABEL version="1.0"
+LABEL description="front de l'application Geotrace"
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install --production
+RUN npm run build
+RUN npm install -g serve
+RUN rm -r n* p* src/ tsconfig.json
+
+EXPOSE 3000
+
+CMD ["serve", "-s" , "build"] 
+
+
+
+
+
+
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "geotrace-init",
+  "name": "front-geotrace",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "geotrace-init",
+      "name": "front-geotrace",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.10.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "geotrace-init",
+  "name": "front-geotrace",
   "version": "0.1.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Création du **Dockerfile** qui permet de crée une image en mode production ( outils de dev retirés ). 

le container écoute sur le port : 3000

pour crée l'image taper cette commande : `docker build -t front-geotrace .` ( à la racine de front-geotrace) 

ensuite pour lancer le container, taper cette commande : `docker run -d -p 80:3000 front-geotrace`



